### PR TITLE
Re-factored HackRF CMAKE file to scan updated library directories. (Gets new HackRF firmware working with this)

### DIFF
--- a/cmake/Modules/FindHACKRF.cmake
+++ b/cmake/Modules/FindHACKRF.cmake
@@ -11,7 +11,7 @@
 
 FIND_PATH(HACKRF_INCLUDE_DIR hackrf.h
   ${HACKRF_DIR}/include
-  /usr/local/include/libhackrf
+  /usr/include/libhackrf
 )
 
 FIND_LIBRARY(HACKRF_LIBRARY
@@ -22,6 +22,7 @@ FIND_LIBRARY(HACKRF_LIBRARY
   /usr/lib64
   /usr/lib
   /usr/local/lib
+  /usr/lib/x86_64-linux-gnu
   NO_DEFAULT_PATH
 )
 


### PR DESCRIPTION
Thanks to this issue: https://github.com/JiaoXianjun/LTE-Cell-Scanner/issues/15 I was able to get this project working on the newest HackRF firmware (2018.1). Ended up being two small changes to the cmake file, hope this helps.

If this doesn't work, run "whereis libhackrf". 

Two directories you need to find from there:
-The last entry (Should be a directory similar to /usr/include/ - Do NOT add the libhackrf part, just the directory)
-The first entry (It'll be an entry showing the path to the shared object file- again just copy the directory path, WITHOUT the shared object file.)