### PR TITLE
add search pathes for 64bit kali on raspi

### DIFF
--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -21,6 +21,7 @@ FIND_LIBRARY(FFTW_LIBRARY
   PATHS ${FFTW_DIR}/libs
   "${FFTW_DIR}\\win32\\lib"
   /usr/lib/x86_64-linux-gnu
+  /usr/lib/aarch64-linux-gnu
   /usr/pkgs64/lib
   /usr/lib64
   /usr/lib

--- a/cmake/Modules/FindHACKRF.cmake
+++ b/cmake/Modules/FindHACKRF.cmake
@@ -12,6 +12,7 @@
 FIND_PATH(HACKRF_INCLUDE_DIR hackrf.h
   ${HACKRF_DIR}/include
   /usr/local/include/libhackrf
+  /usr/include/libhackrf
 )
 
 FIND_LIBRARY(HACKRF_LIBRARY
@@ -19,6 +20,7 @@ FIND_LIBRARY(HACKRF_LIBRARY
   PATHS ${HACKRF_DIR}/libs
   "${HACKRF_DIR}\\win32\\lib"
   /usr/pkgs64/lib
+  /usr/lib/aarch64-linux-gnu
   /usr/lib64
   /usr/lib
   /usr/local/lib

--- a/cmake/Modules/FindITPP.cmake
+++ b/cmake/Modules/FindITPP.cmake
@@ -23,6 +23,7 @@ FIND_LIBRARY(ITPP_LIBRARY_NORMAL
   /usr/pkgs64/lib
   /usr/lib64
   /usr/lib/x86_64-linux-gnu
+  /usr/lib/aarch64-linux-gnu
   /usr/lib
   /usr/local/lib
   NO_DEFAULT_PATH


### PR DESCRIPTION
build for hackrf works, results of cellsearch look reasonable