### PR TITLE
Add library paths for arm (raspberry pi)

### DIFF
--- a/cmake/Modules/FindBLADERF.cmake
+++ b/cmake/Modules/FindBLADERF.cmake
@@ -23,6 +23,7 @@ FIND_LIBRARY(BLADERF_LIBRARY
   /usr/lib/x86_64-linux-gnu/
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf
   NO_DEFAULT_PATH
 )
 

--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -26,6 +26,7 @@ FIND_LIBRARY(FFTW_LIBRARY
   /usr/lib64
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf
   NO_DEFAULT_PATH
 )
 

--- a/cmake/Modules/FindHACKRF.cmake
+++ b/cmake/Modules/FindHACKRF.cmake
@@ -25,6 +25,7 @@ FIND_LIBRARY(HACKRF_LIBRARY
   /usr/lib
   /usr/local/lib
   /usr/lib/x86_64-linux-gnu
+  /usr/lib/arm-linux-gnueabihf
   NO_DEFAULT_PATH
 )
 

--- a/cmake/Modules/FindITPP.cmake
+++ b/cmake/Modules/FindITPP.cmake
@@ -26,6 +26,7 @@ FIND_LIBRARY(ITPP_LIBRARY_NORMAL
   /usr/lib/aarch64-linux-gnu
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf
   NO_DEFAULT_PATH
 )
 

--- a/cmake/Modules/FindRTLSDR.cmake
+++ b/cmake/Modules/FindRTLSDR.cmake
@@ -25,6 +25,7 @@ FIND_LIBRARY(RTLSDR_LIBRARY
   /usr/lib/x86_64-linux-gnu
   /usr/lib
   /usr/local/lib
+  /usr/lib/arm-linux-gnueabihf
   NO_DEFAULT_PATH
 )
 


### PR DESCRIPTION
Add CMake library search paths to build on ARM (Raspberry PI). Probably the same for OpenCL but did not validate that. This does work for Raspberry PI.